### PR TITLE
ci: fix malformed configuration of golangci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -214,9 +214,6 @@ linters-settings:
   misspell:
     #locale: US
     ignore-words:
-  whitespace:
-    multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
-    multi-func: false # Enforces newlines (or comments) after every multi-line function signature
   wsl:
     # If true append is only allowed to be cuddled if appending value is
     # matching variables, fields or types on line above. Default is true.


### PR DESCRIPTION
Removing a duplicate block.

Addressing:
run golangci-lint
   Running [/home/runner/golangci-lint-1.54.2-linux-amd64/golangci-lint run --out-format=github-actions -v --config ./.golangci.yml] in [] ...
level=error msg="Can't read config: can't read viper config: While parsing config: yaml: unmarshal errors:\n  line 217: mapping key \"whitespace\" already defined at line 209"